### PR TITLE
Enhance Embed to support config status and allow index and structure files to passed through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,5 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 src/industrial_classification_utils/data/vector_store/*
+
+.vscode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sic-classification-utils"
-version = "0.1.1"
+version = "0.1.2"
 description = "Utility functions used for SIC classification"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ packages = [{ include = "industrial_classification_utils", from = "src" }]
 
 include = [
   { path = "src/industrial_classification_utils/data", format = "sdist" },
-  { path = "src/industrial_classification_utils/data", format = "wheel" }
+  { path = "src/industrial_classification_utils/data", format = "wheel" },
+  { path = "src/industrial_classification_utils/data/**/*.xlsx", format = "sdist" },
+  { path = "src/industrial_classification_utils/data/**/*.xlsx", format = "wheel" },
+  { path = "src/industrial_classification_utils/data/**/*.txt", format = "sdist" },
+  { path = "src/industrial_classification_utils/data/**/*.txt", format = "wheel" }
 ]
 
 [tool.poetry.dependencies]

--- a/src/industrial_classification_utils/embed/embedding.py
+++ b/src/industrial_classification_utils/embed/embedding.py
@@ -41,6 +41,7 @@ embedding_config = {
     "index_size": 0,
 }
 
+
 def get_config() -> dict[str, dict[str, str]]:
     """Returns the configuration dictionary for the LLM.
 
@@ -117,7 +118,9 @@ class EmbeddingHandler:
 
         # 🔄 Update shared config
         embedding_config["embedding_model_name"] = embedding_model_name
-        embedding_config["llm_model_name"] = config["llm"].get("llm_model_name", "unknown")
+        embedding_config["llm_model_name"] = config["llm"].get(
+            "llm_model_name", "unknown"
+        )
         embedding_config["db_dir"] = db_dir
         embedding_config["matches"] = self.k_matches
         embedding_config["index_size"] = self._index_size
@@ -137,7 +140,7 @@ class EmbeddingHandler:
             embedding_function=self.embeddings, persist_directory=self.db_dir
         )
 
-    def embed_index(
+    def embed_index(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         from_empty: bool = True,
         sic: Optional[SIC] = None,
@@ -229,7 +232,9 @@ class EmbeddingHandler:
         embedding_config["matches"] = self.k_matches
         embedding_config["db_dir"] = self.db_dir
         embedding_config["embedding_model_name"] = self.embeddings.model_name
-        embedding_config["llm_model_name"] = config["llm"].get("llm_model_name", "unknown")
+        embedding_config["llm_model_name"] = config["llm"].get(
+            "llm_model_name", "unknown"
+        )
 
     def search_index(
         self, query: str, return_dicts: bool = True
@@ -279,7 +284,6 @@ class EmbeddingHandler:
         short_list = [y for x in search_terms_list for y in self.search_index(query=x)]
         return sorted(short_list, key=lambda x: x["distance"])  # type: ignore
 
-
     def get_embed_config(self) -> dict:
         """Returns the current embedding configuration as a dictionary."""
         return {
@@ -289,6 +293,6 @@ class EmbeddingHandler:
             "sic_index": str(embedding_config["sic_index"]),
             "sic_structure": str(embedding_config["sic_structure"]),
             "sic_condensed": str(embedding_config["sic_condensed"]),
-            "matches": int(embedding_config["matches"]),
-            "index_size": int(embedding_config["index_size"]),
+            "matches": embedding_config["matches"],
+            "index_size": embedding_config["index_size"],
         }

--- a/src/industrial_classification_utils/embed/embedding.py
+++ b/src/industrial_classification_utils/embed/embedding.py
@@ -29,6 +29,17 @@ from industrial_classification_utils.utils.sic_data_access import (
 
 logger = logging.getLogger(__name__)
 
+# Share configuration with other modules
+embedding_config = {
+    "embedding_model_name": "unknown",
+    "llm_model_name": "unknown",
+    "db_dir": "unknown",
+    "sic_index": "unknown",
+    "sic_structure": "unknown",
+    "sic_condensed": "unknown",
+    "matches": 0,
+    "index_size": 0,
+}
 
 def get_config() -> dict[str, dict[str, str]]:
     """Returns the configuration dictionary for the LLM.
@@ -104,6 +115,13 @@ class EmbeddingHandler:
         self.spell = Speller()
         self._index_size = self.vector_store._client.get_collection("langchain").count()
 
+        # 🔄 Update shared config
+        embedding_config["embedding_model_name"] = embedding_model_name
+        embedding_config["llm_model_name"] = config["llm"].get("llm_model_name", "unknown")
+        embedding_config["db_dir"] = db_dir
+        embedding_config["matches"] = self.k_matches
+        embedding_config["index_size"] = self._index_size
+
     def _create_vector_store(self) -> Chroma:
         """Initializes the Chroma vector store.
 
@@ -124,6 +142,8 @@ class EmbeddingHandler:
         from_empty: bool = True,
         sic: Optional[SIC] = None,
         file_object=None,
+        sic_index_file=None,
+        sic_structure_file=None,
     ):
         """Embeds the index entries into the vector store.
 
@@ -135,6 +155,10 @@ class EmbeddingHandler:
             file_object (StringIO object, optional): The index file as a StringIO object.
                 If provided, the file will be read line by line and embedded.
                 Each line should have the format **code**: **description**.
+            sic_index_file (optional): Custom path or file-like object to override
+                default SIC index source.
+            sic_structure_file (optional): Custom path or file-like object to override
+                default SIC structure source.
         """
         if from_empty:
             self.vector_store._client.delete_collection(  # pylint: disable=protected-access
@@ -162,8 +186,12 @@ class EmbeddingHandler:
 
         else:
             if sic is None:
-                sic_index_df = load_sic_index(config["lookups"]["sic_index"])
-                sic_df = load_sic_structure(config["lookups"]["sic_structure"])
+                sic_index_df = load_sic_index(
+                    sic_index_file or config["lookups"]["sic_index"]
+                )
+                sic_df = load_sic_structure(
+                    sic_structure_file or config["lookups"]["sic_structure"]
+                )
                 sic = load_hierarchy(sic_df, sic_index_df)
 
             logger.debug("Loading entries from SIC hierarchy for embedding.")
@@ -188,6 +216,20 @@ class EmbeddingHandler:
         logger.debug(
             "Inserted %s entries into vector embedding database.", f"{len(docs):,}"
         )
+
+        # Update shared config
+        embedding_config["index_size"] = self._index_size
+        embedding_config["sic_index"] = sic_index_file or config["lookups"]["sic_index"]
+        embedding_config["sic_structure"] = (
+            sic_structure_file or config["lookups"]["sic_structure"]
+        )
+        embedding_config["sic_condensed"] = (
+            sic_index_file or config["lookups"]["sic_condensed"]
+        )
+        embedding_config["matches"] = self.k_matches
+        embedding_config["db_dir"] = self.db_dir
+        embedding_config["embedding_model_name"] = self.embeddings.model_name
+        embedding_config["llm_model_name"] = config["llm"].get("llm_model_name", "unknown")
 
     def search_index(
         self, query: str, return_dicts: bool = True
@@ -236,3 +278,17 @@ class EmbeddingHandler:
             search_terms_list.add(self.spell(x))
         short_list = [y for x in search_terms_list for y in self.search_index(query=x)]
         return sorted(short_list, key=lambda x: x["distance"])  # type: ignore
+
+
+    def get_embed_config(self) -> dict:
+        """Returns the current embedding configuration as a dictionary."""
+        return {
+            "embedding_model_name": str(embedding_config["embedding_model_name"]),
+            "llm_model_name": str(embedding_config["llm_model_name"]),
+            "db_dir": str(embedding_config["db_dir"]),
+            "sic_index": str(embedding_config["sic_index"]),
+            "sic_structure": str(embedding_config["sic_structure"]),
+            "sic_condensed": str(embedding_config["sic_condensed"]),
+            "matches": int(embedding_config["matches"]),
+            "index_size": int(embedding_config["index_size"]),
+        }


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

The changes allow sic_classification index and strucure files to be passed in by the code using the library.
Also adds get_embed_config which return status information about the embedding vector store

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] Feature implementation (feat:)
- [x] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Clone the repo and run make all-tests