### PR TITLE
Sa 103 vector store cloud run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sic-classification-utils"
-version = "0.1.2"
+version = "0.1.3"
 description = "Utility functions used for SIC classification"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"

--- a/src/industrial_classification_utils/embed/embedding.py
+++ b/src/industrial_classification_utils/embed/embedding.py
@@ -116,9 +116,7 @@ class EmbeddingHandler:
         else:
             self.embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
 
-        logger.info(
-            "Using embedding model: %s", embedding_model_name
-        )
+        logger.info("Using embedding model: %s", embedding_model_name)
 
         self.db_dir = db_dir
         self.vector_store = self._create_vector_store()
@@ -127,7 +125,11 @@ class EmbeddingHandler:
         self.spell = Speller()
         self._index_size = self.vector_store._client.get_collection("langchain").count()
 
-        logger.info("Vector store created in: %s containing %s entries.", self.db_dir, self._index_size)
+        logger.info(
+            "Vector store created in: %s containing %s entries.",
+            self.db_dir,
+            self._index_size,
+        )
 
         # 🔄 Update shared config
         embedding_config["embedding_model_name"] = embedding_model_name

--- a/src/industrial_classification_utils/embed/embedding.py
+++ b/src/industrial_classification_utils/embed/embedding.py
@@ -281,7 +281,7 @@ class EmbeddingHandler:
             sic_structure_file or config["lookups"]["sic_structure"]
         )
         embedding_config["sic_condensed"] = (
-            sic_index_file or config["lookups"]["sic_condensed"]
+            config["lookups"]["sic_condensed"]
         )
         embedding_config["matches"] = self.k_matches
         embedding_config["db_dir"] = self.db_dir

--- a/src/industrial_classification_utils/llm/llm.py
+++ b/src/industrial_classification_utils/llm/llm.py
@@ -310,7 +310,9 @@ class ClassificationLLM:
             return call_dict
 
         if short_list is None:
-            raise ValueError("Short list is None - list provided from embedding search.")
+            raise ValueError(
+                "Short list is None - list provided from embedding search."
+            )
 
         sic_codes = self._prompt_candidate_list(
             short_list, code_digits=code_digits, candidates_limit=candidates_limit
@@ -530,7 +532,9 @@ class ClassificationLLM:
             return call_dict
 
         if short_list is None:
-            raise ValueError("Short list is None - list provided from embedding search.")
+            raise ValueError(
+                "Short list is None - list provided from embedding search."
+            )
 
         sic_codes = self._prompt_candidate_list(
             short_list, code_digits=code_digits, candidates_limit=candidates_limit

--- a/src/industrial_classification_utils/llm/llm_embedding_example.py
+++ b/src/industrial_classification_utils/llm/llm_embedding_example.py
@@ -10,7 +10,6 @@ The example then uses llm from the `industrial_classification_utils.llm.llm_embe
 package to perform a lookup using the embeddings index.
 """
 
-from industrial_classification_utils.embed.embedding import EmbeddingHandler
 from industrial_classification_utils.llm.llm import ClassificationLLM
 
 EXAMPLE_QUERY = "school teacher primary education"
@@ -20,23 +19,51 @@ JOB_DESCRIPTION = "teach maths"
 ORG_DESCRIPTION = "school"
 CANDIDATE_LIMIT = 100
 
-print("Creating embeddings index...")
-# Create the embeddings index
-embed = EmbeddingHandler()
-gemini_llm = ClassificationLLM(model_name=LLM_MODEL, embedding_handler=embed)
+# The following is a mock response for the embedding search
+EXAMPLE_EMBED_SHORT_LIST = [
+    {
+        "distance": 0.6347243785858154,
+        "title": "Education agent",
+        "code": "85600",
+        "four_digit_code": "8560",
+        "two_digit_code": "85"
+    },
+    {
+        "distance": 0.6422433257102966,
+        "title": "Teacher n.e.c.",
+        "code": "85590",
+        "four_digit_code": "8559",
+        "two_digit_code": "85"
+    },
+    {
+        "distance": 0.7757259607315063,
+        "title": "Teachers of sport",
+        "code": "85510",
+        "four_digit_code": "8551",
+        "two_digit_code": "85"
+    },
+    {
+        "distance": 0.8803297281265259,
+        "title": "Kindergartens",
+        "code": "85100",
+        "four_digit_code": "8510",
+        "two_digit_code": "85"
+    }
+]
 
-embed.embed_index(from_empty=False)
-print(
-    f"Embeddings index created with {embed._index_size} entries."  # pylint: disable=protected-access
-)
 
-print(f"Performing LLM lookup for {JOB_TITLE}...")
+# The vector store is decoupled from the LLM.
+# The expectation is that the embedding will be queried and then
+# the results will be passed to the LLM for classification.
+# This example uses mocked data for the embedding search.
+gemini_llm = ClassificationLLM(model_name=LLM_MODEL)
 
 response, short_list, prompt = gemini_llm.sa_rag_sic_code(
     ORG_DESCRIPTION,
     JOB_TITLE,
     JOB_DESCRIPTION,
     candidates_limit=CANDIDATE_LIMIT,
+    short_list=EXAMPLE_EMBED_SHORT_LIST,
 )
 
 # Print the response

--- a/src/industrial_classification_utils/llm/llm_embedding_example.py
+++ b/src/industrial_classification_utils/llm/llm_embedding_example.py
@@ -26,29 +26,29 @@ EXAMPLE_EMBED_SHORT_LIST = [
         "title": "Education agent",
         "code": "85600",
         "four_digit_code": "8560",
-        "two_digit_code": "85"
+        "two_digit_code": "85",
     },
     {
         "distance": 0.6422433257102966,
         "title": "Teacher n.e.c.",
         "code": "85590",
         "four_digit_code": "8559",
-        "two_digit_code": "85"
+        "two_digit_code": "85",
     },
     {
         "distance": 0.7757259607315063,
         "title": "Teachers of sport",
         "code": "85510",
         "four_digit_code": "8551",
-        "two_digit_code": "85"
+        "two_digit_code": "85",
     },
     {
         "distance": 0.8803297281265259,
         "title": "Kindergartens",
         "code": "85100",
         "four_digit_code": "8510",
-        "two_digit_code": "85"
-    }
+        "two_digit_code": "85",
+    },
 ]
 
 

--- a/src/industrial_classification_utils/llm/prompt.py
+++ b/src/industrial_classification_utils/llm/prompt.py
@@ -39,6 +39,9 @@ from industrial_classification_utils.models.response_model import (
     SurveyAssistSicResponse,
     UnambiguousResponse,
 )
+from industrial_classification_utils.utils.sic_data_access import (
+    load_text_from_config,
+)
 
 config = get_config()
 
@@ -65,8 +68,8 @@ Make sure to use the provided 2007 SIC Index.
 {sic_index}
 """
 
-with open(config["lookups"]["sic_condensed"], encoding="utf-8") as f:
-    sic_index = f.read()
+
+sic_index = load_text_from_config(config["lookups"]["sic_condensed"])
 
 
 parser = PydanticOutputParser(  # type: ignore # Suspect langchain ver bug

--- a/src/industrial_classification_utils/llm/prompt.py
+++ b/src/industrial_classification_utils/llm/prompt.py
@@ -68,9 +68,8 @@ Make sure to use the provided 2007 SIC Index.
 {sic_index}
 """
 
-
+# Load the SIC index from the configuration and convert to file path string
 sic_index = load_text_from_config(config["lookups"]["sic_condensed"])
-
 
 parser = PydanticOutputParser(  # type: ignore # Suspect langchain ver bug
     pydantic_object=SicResponse

--- a/src/industrial_classification_utils/models/config_model.py
+++ b/src/industrial_classification_utils/models/config_model.py
@@ -1,0 +1,53 @@
+"""This module defines configuration models for the industrial classification utilities.
+
+The models are implemented using Python's `TypedDict` and are used to represent
+configuration settings for various components of the system, such as language
+models and lookup tables.
+
+Classes:
+    LLMConfig: Configuration for language and embedding models.
+    LookupsConfig: Configuration for SIC-related lookup tables.
+"""
+
+from typing import TypedDict
+
+
+class LLMConfig(TypedDict):
+    """Configuration for language and embedding models and location of
+    the vector store.
+
+    Attributes:
+        llm_model_name (str): Name of the language model.
+        embedding_model_name (str): Name of the embedding model.
+        db_dir (str): Directory for the database.
+    """
+
+    llm_model_name: str
+    embedding_model_name: str
+    db_dir: str
+
+
+class LookupsConfig(TypedDict):
+    """Configuration for SIC-related lookup tables.
+
+    Attributes:
+        sic_index (tuple[str, str]): Path to the SIC index file.
+        sic_structure (tuple[str, str]): Path to the SIC structure file.
+        sic_condensed (tuple[str, str]): Path to the condensed SIC file.
+    """
+
+    sic_index: tuple[str, str]
+    sic_structure: tuple[str, str]
+    sic_condensed: tuple[str, str]
+
+
+class FullConfig(TypedDict):
+    """Full configuration model for the SIC classification.
+
+    Attributes:
+        llm (LLMConfig): Configuration for language and embedding models.
+        lookups (LookupsConfig): Configuration for SIC-related lookup tables.
+    """
+
+    llm: LLMConfig
+    lookups: LookupsConfig

--- a/src/industrial_classification_utils/utils/sic_data_access.py
+++ b/src/industrial_classification_utils/utils/sic_data_access.py
@@ -5,13 +5,14 @@ SIC-related Excel files. The filepaths for these files are defined in
 the configuration function in `embedding.py`.
 """
 
+import logging
 from importlib.resources import files
 
-import logging
 import pandas as pd
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
 
 def load_sic_index(resource_ref: tuple[str, str]) -> pd.DataFrame:
     """Loads the SIC index from an Excel file.
@@ -29,7 +30,7 @@ def load_sic_index(resource_ref: tuple[str, str]) -> pd.DataFrame:
     pkg, filename = resource_ref
     file_path = files(pkg).joinpath(filename)
 
-    logger.debug(f"Loading SIC index from {file_path}")
+    logger.debug("Loading SIC index from %s", file_path)
 
     sic_index_df = pd.read_excel(
         file_path,
@@ -62,7 +63,7 @@ def load_sic_structure(resource_ref: tuple[str, str]) -> pd.DataFrame:
     pkg, filename = resource_ref
     file_path = files(pkg).joinpath(filename)
 
-    logger.debug(f"Loading SIC structure from {file_path}")
+    logger.debug("Loading SIC structure from %s", file_path)
 
     sic_df = pd.read_excel(
         file_path,
@@ -85,12 +86,23 @@ def load_sic_structure(resource_ref: tuple[str, str]) -> pd.DataFrame:
 
 
 def load_text_from_config(config_section: tuple[str, str]) -> str:
-    from importlib.resources import files
+    """Loads text content from a configuration file.
 
+    This function reads the content of a text file specified by the given
+    configuration section and returns it as a string.
+
+    Args:
+        config_section (tuple[str, str]): A tuple containing the package name
+            and the filename of the configuration file.
+
+    Returns:
+        str: The content of the configuration file as a string.
+
+    """
     pkg, filename = config_section
     file_path = files(pkg).joinpath(filename)
 
-    logger.debug(f"Loading text from {file_path}")
+    logger.debug("Loading text from %s", file_path)
 
-    with open(file_path, encoding="utf-8") as f:
+    with file_path.open(encoding="utf-8") as f:
         return f.read()

--- a/src/industrial_classification_utils/utils/sic_data_access.py
+++ b/src/industrial_classification_utils/utils/sic_data_access.py
@@ -10,7 +10,7 @@ from importlib.resources import files
 
 import pandas as pd
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -30,7 +30,7 @@ def load_sic_index(resource_ref: tuple[str, str]) -> pd.DataFrame:
     pkg, filename = resource_ref
     file_path = files(pkg).joinpath(filename)
 
-    logger.debug("Loading SIC index from %s", file_path)
+    logger.info("Loading SIC index from %s", file_path)
 
     sic_index_df = pd.read_excel(
         file_path,
@@ -63,7 +63,7 @@ def load_sic_structure(resource_ref: tuple[str, str]) -> pd.DataFrame:
     pkg, filename = resource_ref
     file_path = files(pkg).joinpath(filename)
 
-    logger.debug("Loading SIC structure from %s", file_path)
+    logger.info("Loading SIC structure from %s", file_path)
 
     sic_df = pd.read_excel(
         file_path,
@@ -102,7 +102,7 @@ def load_text_from_config(config_section: tuple[str, str]) -> str:
     pkg, filename = config_section
     file_path = files(pkg).joinpath(filename)
 
-    logger.debug("Loading text from %s", file_path)
+    logger.info("Loading text from %s", file_path)
 
     with file_path.open(encoding="utf-8") as f:
         return f.read()

--- a/src/industrial_classification_utils/utils/sic_data_access.py
+++ b/src/industrial_classification_utils/utils/sic_data_access.py
@@ -5,24 +5,34 @@ SIC-related Excel files. The filepaths for these files are defined in
 the configuration function in `embedding.py`.
 """
 
+from importlib.resources import files
+
+import logging
 import pandas as pd
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
-def load_sic_index(filepath: str) -> pd.DataFrame:
+def load_sic_index(resource_ref: tuple[str, str]) -> pd.DataFrame:
     """Loads the SIC index from an Excel file.
 
     The SIC index provides a list of around 15,000 activities and their
     associated 5-digit SIC codes.
 
     Args:
-        filepath (str): The path to the Excel file containing the SIC index.
+        resource_ref (tuple): The path to the Excel file containing the SIC index.
 
     Returns:
         pd.DataFrame: A DataFrame containing the SIC index with columns
         `uk_sic_2007` and `activity`.
     """
+    pkg, filename = resource_ref
+    file_path = files(pkg).joinpath(filename)
+
+    logger.debug(f"Loading SIC index from {file_path}")
+
     sic_index_df = pd.read_excel(
-        filepath,
+        file_path,
         sheet_name="Alphabetical Index",
         skiprows=2,
         usecols=["UK SIC 2007", "Activity"],
@@ -36,21 +46,26 @@ def load_sic_index(filepath: str) -> pd.DataFrame:
     return sic_index_df
 
 
-def load_sic_structure(filepath: str) -> pd.DataFrame:
+def load_sic_structure(resource_ref: tuple[str, str]) -> pd.DataFrame:
     """Loads the SIC structure from an Excel file.
 
     This function loads a worksheet containing all the levels and names
     of the UK SIC 2007 hierarchy.
 
     Args:
-        filepath (str): The path to the Excel file containing the SIC structure.
+        resource_ref (tuple): The path to the Excel file containing the SIC structure.
 
     Returns:
         pd.DataFrame: A DataFrame containing the SIC structure with columns
         `description`, `section`, `most_disaggregated_level`, and `level_headings`.
     """
+    pkg, filename = resource_ref
+    file_path = files(pkg).joinpath(filename)
+
+    logger.debug(f"Loading SIC structure from {file_path}")
+
     sic_df = pd.read_excel(
-        filepath,
+        file_path,
         sheet_name="reworked structure",
         usecols=[
             "Description",
@@ -67,3 +82,15 @@ def load_sic_structure(filepath: str) -> pd.DataFrame:
         sic_df[col] = sic_df[col].str.strip()
 
     return sic_df
+
+
+def load_text_from_config(config_section: tuple[str, str]) -> str:
+    from importlib.resources import files
+
+    pkg, filename = config_section
+    file_path = files(pkg).joinpath(filename)
+
+    logger.debug(f"Loading text from {file_path}")
+
+    with open(file_path, encoding="utf-8") as f:
+        return f.read()

--- a/tests/test_sic_data_access.py
+++ b/tests/test_sic_data_access.py
@@ -4,7 +4,7 @@ This module contains tests for the `load_sic_index` and `load_sic_structure`
 functions from the `industrial_classification_utils.utils.sic_data_access` module.
 """
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pandas as pd
 import pytest
@@ -61,15 +61,19 @@ def test_load_sic_index(mock_read_excel, mock_sic_index_data):
         - The returned DataFrame matches the mock SIC index data.
     """
     mock_read_excel.return_value = mock_sic_index_data
-    filepath = "dummy_path.xlsx"
-    result = load_sic_index(filepath)
+    result = load_sic_index(("industrial_classification_utils.data.sic_index", "uksic2007indexeswithaddendumdecember2022.xlsx"))
+
     mock_read_excel.assert_called_once_with(
-        filepath,
+        ANY,
         sheet_name="Alphabetical Index",
         skiprows=2,
         usecols=["UK SIC 2007", "Activity"],
         dtype=str,
     )
+
+    # Verify the path used in the call
+    called_args, _ = mock_read_excel.call_args
+    assert str(called_args[0]).endswith("uksic2007indexeswithaddendumdecember2022.xlsx")
     assert result.equals(mock_sic_index_data)
 
 
@@ -87,10 +91,9 @@ def test_load_sic_structure(mock_read_excel, mock_sic_structure_data):
         - The returned DataFrame matches the mock SIC structure data.
     """
     mock_read_excel.return_value = mock_sic_structure_data
-    filepath = "dummy_path.xlsx"
-    result = load_sic_structure(filepath)
+    result = load_sic_structure(("industrial_classification_utils.data.sic_index", "publisheduksicsummaryofstructureworksheet.xlsx"))
     mock_read_excel.assert_called_once_with(
-        filepath,
+        ANY,
         sheet_name="reworked structure",
         usecols=[
             "Description",
@@ -100,4 +103,9 @@ def test_load_sic_structure(mock_read_excel, mock_sic_structure_data):
         ],
         dtype=str,
     )
+
+    # Verify the path used in the call
+    called_args, _ = mock_read_excel.call_args
+    assert str(called_args[0]).endswith("publisheduksicsummaryofstructureworksheet.xlsx")
+
     assert result.equals(mock_sic_structure_data)

--- a/tests/test_sic_data_access.py
+++ b/tests/test_sic_data_access.py
@@ -61,7 +61,12 @@ def test_load_sic_index(mock_read_excel, mock_sic_index_data):
         - The returned DataFrame matches the mock SIC index data.
     """
     mock_read_excel.return_value = mock_sic_index_data
-    result = load_sic_index(("industrial_classification_utils.data.sic_index", "uksic2007indexeswithaddendumdecember2022.xlsx"))
+    result = load_sic_index(
+        (
+            "industrial_classification_utils.data.sic_index",
+            "uksic2007indexeswithaddendumdecember2022.xlsx",
+        )
+    )
 
     mock_read_excel.assert_called_once_with(
         ANY,
@@ -91,7 +96,12 @@ def test_load_sic_structure(mock_read_excel, mock_sic_structure_data):
         - The returned DataFrame matches the mock SIC structure data.
     """
     mock_read_excel.return_value = mock_sic_structure_data
-    result = load_sic_structure(("industrial_classification_utils.data.sic_index", "publisheduksicsummaryofstructureworksheet.xlsx"))
+    result = load_sic_structure(
+        (
+            "industrial_classification_utils.data.sic_index",
+            "publisheduksicsummaryofstructureworksheet.xlsx",
+        )
+    )
     mock_read_excel.assert_called_once_with(
         ANY,
         sheet_name="reworked structure",
@@ -106,6 +116,8 @@ def test_load_sic_structure(mock_read_excel, mock_sic_structure_data):
 
     # Verify the path used in the call
     called_args, _ = mock_read_excel.call_args
-    assert str(called_args[0]).endswith("publisheduksicsummaryofstructureworksheet.xlsx")
+    assert str(called_args[0]).endswith(
+        "publisheduksicsummaryofstructureworksheet.xlsx"
+    )
 
     assert result.equals(mock_sic_structure_data)


### PR DESCRIPTION
# 📌 Pull Request Template

Changes to enable the sic-classification-utils logic to support a standalone vector store service.

## ✨ Summary

Change file references from text paths to file and path references so they can be loaded from the package calling the functionality.

## 📜 Changes Introduced

- Added type definitions for the config structure
- Introduced logging and error handling to enable extra observability to the building of the vector store
- Changed file references to package structure rather than file paths
- Removed some unused logic and prompts
- Update prompts to take the shortlist of candidates as a parameter (detaching the LLM from the vector search)
- Updated example code to use a mocked short list from the standalone vector store
- Updated existing tests to use package reference for excel files

- [X] Feature implementation (feat:) 
- [X] Updates to tests and/or documentation
- **N/A** Terraform changes (if applicable)

## ✅ Checklist

- [X] Code is formatted using **Black**
- [X] Imports are sorted using **isort**
- [X] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [X] Security checks pass using **Bandit**
- [X] API and Unit tests are written and pass using **pytest**
- **N/A** Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [X] DocStrings follow Google-style and are added as per Pylint recommendations
- [X] Documentation has been updated if needed

## 🔍 How to Test

Clone the repo and run both examples in the code locally (llm_embedding_example.py and sic_embedding_example.py).
make all-tests