### PR TITLE
SA-247 Implement prompt for final SIC assignment using initial respondent data and answers to follow-up questions

### DIFF
--- a/src/industrial_classification_utils/llm/llm.py
+++ b/src/industrial_classification_utils/llm/llm.py
@@ -31,12 +31,14 @@ from industrial_classification_utils.embed.embedding import get_config
 from industrial_classification_utils.llm.prompt import (
     GENERAL_PROMPT_RAG,
     SA_SIC_PROMPT_RAG,
+    SIC_PROMPT_FINAL_ASSIGNMENT,
     SIC_PROMPT_PYDANTIC,
     SIC_PROMPT_RAG,
     SIC_PROMPT_RERANKER,
     SIC_PROMPT_UNAMBIGUOUS,
 )
 from industrial_classification_utils.models.response_model import (
+    FinalSICAssignment,
     RerankingResponse,
     SicResponse,
     SurveyAssistSicResponse,
@@ -108,6 +110,7 @@ class ClassificationLLM:
         self.general_prompt_rag = GENERAL_PROMPT_RAG
         self.sic_prompt_unambiguous = SIC_PROMPT_UNAMBIGUOUS
         self.sic_prompt_reranker = SIC_PROMPT_RERANKER
+        self.sic_prompt_final = SIC_PROMPT_FINAL_ASSIGNMENT
         self.sic = None
         self.verbose = verbose
 
@@ -587,3 +590,128 @@ class ClassificationLLM:
             )
 
         return validated_answer, short_list, call_dict
+
+    def final_sic_code(  # noqa: PLR0913
+        self,
+        industry_descr: str,
+        job_title: Optional[str] = None,
+        job_description: Optional[str] = None,
+        sic_candidates: Optional[str] = None,
+        open_question: Optional[str] = None,
+        answer_to_open_question: Optional[str] = None,
+        closed_question: Optional[str] = None,
+        answer_to_closed_question: Optional[str] = None,
+    ) -> tuple[FinalSICAssignment, Optional[Any]]:
+        """Evaluates codability to a single 5-digit SIC code based on respondent's data
+            and answers to follow-up questions.
+
+        Args:
+            industry_descr (str): The description of the industry.
+            job_title (str, optional): The job title. Defaults to None.
+            job_description (str, optional): The job description. Defaults to None.
+            sic_candidates: (str, optional): Short list of SIC candidates to pass to LLM.
+            open_question (str, optional): The open question. Defaults to None.
+            answer_to_open_question (str, optional): The answer to the open question.
+                Defaults to None.
+            closed_question (str, optional): The closed question. Defaults to None.
+            answer_to_closed_question (str, optional): The answer to the closed question.
+                Defaults to None.
+
+        Returns:
+            FinalSICAssignment: The generated response to the query.
+
+        Raises:
+            ValueError: If there is an error during the parsing of the response.
+            ValueError: If the default embedding handler is required but
+                not loaded correctly.
+
+        """
+
+        def prep_call_dict(  # noqa: PLR0913
+            industry_descr,
+            job_title,
+            job_description,
+            sic_candidates,
+            open_question,
+            answer_to_open_question,
+            closed_question,
+            answer_to_closed_question,
+        ):
+            # Helper function to prepare the call dictionary
+            is_job_title_present = job_title is None or job_title in {"", " "}
+            job_title = "Unknown" if is_job_title_present else job_title
+
+            is_job_description_present = job_description is None or job_description in {
+                "",
+                " ",
+            }
+            job_description = (
+                "Unknown" if is_job_description_present else job_description
+            )
+
+            call_dict = {
+                "industry_descr": industry_descr,
+                "job_title": job_title,
+                "job_description": job_description,
+                "sic_candidates": sic_candidates,
+                "open_question": open_question,
+                "answer_to_open_question": answer_to_open_question,
+                "closed_question": closed_question,
+                "answer_to_closed_question": answer_to_closed_question,
+            }
+            return call_dict
+
+        call_dict = prep_call_dict(
+            industry_descr=industry_descr,
+            job_title=job_title,
+            job_description=job_description,
+            sic_candidates=sic_candidates,
+            open_question=open_question,
+            answer_to_open_question=answer_to_open_question,
+            closed_question=closed_question,
+            answer_to_closed_question=answer_to_closed_question,
+        )
+
+        if self.verbose:
+            final_prompt = self.sic_prompt_final.format(**call_dict)
+            logger.debug(final_prompt)
+
+        chain = self.sic_prompt_final | self.llm
+
+        try:
+            response = chain.invoke(call_dict, return_only_outputs=True)
+        except ValueError as err:
+            logger.exception(err)
+            logger.warning("Error from chain, exit early")
+            validated_answer = FinalSICAssignment(
+                codable=False,
+                unambiguous_code="N/A",
+                unambiguous_code_descriptive="N/A",
+                higher_level_code="N/A",
+                reasoning="Error from chain, exit early",
+            )
+            return validated_answer, call_dict
+
+        if self.verbose:
+            logger.debug("llm_response=%s", response)
+
+        # Parse the output to the desired format
+        parser = PydanticOutputParser(pydantic_object=FinalSICAssignment)  # type: ignore
+        try:
+            validated_answer = parser.parse(str(response.content))
+        except ValueError as parse_error:
+            logger.exception(parse_error)
+            logger.warning("Failed to parse response:\n%s", response.content)
+
+            reasoning = (
+                f"ERROR parse_error=<{parse_error}>, response=<{response.content}>"
+            )
+            validated_answer = FinalSICAssignment(
+                codable=False,
+                unambiguous_code="N/A",
+                unambiguous_code_descriptive="N/A",
+                higher_level_code="N/A",
+                reasoning=reasoning,
+            )
+
+        return validated_answer, call_dict

--- a/src/industrial_classification_utils/llm/llm_final_prompt_example.py
+++ b/src/industrial_classification_utils/llm/llm_final_prompt_example.py
@@ -1,0 +1,53 @@
+"""This module provides illustration for the use of final SIC assignment prompt with an LLM."""
+
+from pprint import pprint
+
+from industrial_classification_utils.llm.llm import ClassificationLLM
+
+# pylint: disable=duplicate-code
+
+LLM_MODEL = "gemini-1.5-flash"
+JOB_TITLE = "community assessment officer"
+JOB_DESCRIPTION = "social services"
+ORG_DESCRIPTION = "adult social care"
+OPEN_QUESTION = "Could you briefly describe the main types of support or assessments"
+"that you provide to individuals in your community?"
+ANSWER_TO_OPEN_QUESTION = "housing and benefits assistance"
+CLOSED_QUESTION = "Which of these best describes your organisation's activities?"
+ANSWER_TO_CLOSED_QUESTION = "other social work activities without accommodation nec"
+
+
+# The following is a mock LLM output for unambiguous_sic_code
+SIC_CANDIDATES = [
+    {
+        "class_code": "88990",
+        "class_descriptive": "Other social work activities without accommodation nec",
+        "likelihood": 0.8,
+    },
+    {
+        "class_code": "88100",
+        "class_descriptive": "Social work activities without accommodation for the elderly and disabled",
+        "likelihood": 0.6,
+    },
+    {
+        "class_code": "84120",
+        "class_descriptive": "Regulation of the activities of providing health care, education,"
+        "cultural services and other social services, excluding social security",
+        "likelihood": 0.3,
+    },
+]
+
+uni_chat = ClassificationLLM(model_name=LLM_MODEL, verbose=True)
+
+sa_response = uni_chat.final_sic_code(
+    industry_descr=ORG_DESCRIPTION,
+    job_title=JOB_TITLE,
+    job_description=JOB_DESCRIPTION,
+    sic_candidates=str(SIC_CANDIDATES),
+    open_question=OPEN_QUESTION,
+    answer_to_open_question=ANSWER_TO_OPEN_QUESTION,
+    closed_question=CLOSED_QUESTION,
+    answer_to_closed_question=ANSWER_TO_CLOSED_QUESTION,
+)
+
+pprint(sa_response[0].model_dump(), indent=2, width=80)

--- a/src/industrial_classification_utils/llm/llm_final_prompt_example.py
+++ b/src/industrial_classification_utils/llm/llm_final_prompt_example.py
@@ -26,7 +26,8 @@ SIC_CANDIDATES = [
     },
     {
         "class_code": "88100",
-        "class_descriptive": "Social work activities without accommodation for the elderly and disabled",
+        "class_descriptive": "Social work activities without accommodation for the"
+        "elderly and disabled",
         "likelihood": 0.6,
     },
     {

--- a/src/industrial_classification_utils/llm/prompt.py
+++ b/src/industrial_classification_utils/llm/prompt.py
@@ -33,6 +33,7 @@ from langchain.prompts.prompt import PromptTemplate
 
 from industrial_classification_utils.embed.embedding import get_config
 from industrial_classification_utils.models.response_model import (
+    FinalSICAssignment,
     RerankingResponse,
     SicResponse,
     UnambiguousResponse,
@@ -362,6 +363,73 @@ SIC_PROMPT_RERANKER = PromptTemplate.from_template(
     template=_core_prompt + _sic_template_reranker,
     partial_variables={
         "format_instructions": parser_reranker.get_format_instructions(),
+    },
+)
+
+
+_sic_template_final_assignment = """"You are an expert in industrial classifications.
+You are tasked with assigning UK Standard Industrial Classification (SIC) codes to survey
+responses with high confidence.
+
+Key objective: You MUST assign a 5-digit SIC code from the candidates provided. Only provide a higher-level
+code if multiple candidates have nearly identical confidence scores (within 0.2 of each other) AND no single
+can be identified as the clear best match.
+
+Assignment logic:
+1. Default behavior: Assign the highest-confidence 5-digit SIC code from the candidates
+2. Higher-level code exception: Only if two or more codes have confidence scores within 0.2
+ of each other AND you cannot determine a clear winner. Provide the most granular
+higher-level code with X padding to 5-digits (e.g., 8610X for 4-digit confidence, 86XXX for
+3-digit confidence, 8XXXX for 2-digit confidence).
+3. 95% confidence interpretation: This means "more likely than not" given the available evidence -
+not absolute certainty
+
+Key principles:
+1. Focus on Best Fit: Rather than seeking absolute certainty, identify which code best fits the totality of evidence.
+2. Be Decisive: The goal is accurate classification, not perfect certainty. If evidence clearly points to one
+code over others, assign it confidently.
+
+Important: When a respondent's closed question answer directly matches or closely aligns with a SIC code
+description, this constitutes strong evidence for that code.
+
+Follow these steps in order:
+1. Review all available information - respondent data, candidate SIC codes, and follow-up responses
+2. Evaluate each candidate SIC code against all available evidence
+3. Assign confidence scores - Rate each candidate from 0.1 (least likely) to 0.9 (most likely).
+Weight respondent's own descriptions heavily.
+4. Apply assignment logic - Select the candidate with the highest confidence score as your primary assignment.
+Only consider higher-level coding if multiple candidates have nearly identical scores (within 0.2) and you cannot
+differentiate between them
+5. Determine final assignment - Assign best fitting 5-digit code or the most specific higher-level code
+6. Provide clear reasoning - Explain your decision with specific evidence
+
+===Respondent Data===
+- Company's main activity: {industry_descr}
+- Job Title: {job_title}
+- Job Description: {job_description}
+
+===Short list of UK SIC codes===
+{sic_candidates}
+
+===Follow up question 1===
+{open_question}
+{answer_to_open_question}
+
+===Follow up question 2===
+{closed_question}
+{answer_to_closed_question}
+
+===Output Format===
+{format_instructions}
+"""
+parser_final_assignment = PydanticOutputParser(  # type: ignore # Suspect langchain ver bug
+    pydantic_object=FinalSICAssignment
+)
+
+SIC_PROMPT_FINAL_ASSIGNMENT = PromptTemplate.from_template(
+    template=_core_prompt + _sic_template_final_assignment,
+    partial_variables={
+        "format_instructions": parser_final_assignment.get_format_instructions(),
     },
 )
 

--- a/src/industrial_classification_utils/models/response_model.py
+++ b/src/industrial_classification_utils/models/response_model.py
@@ -458,8 +458,8 @@ class FinalSICAssignment(BaseModel):
         unambiguous_code (Optional[str]): Full 5-digit classification code
             assigned based on provided respondent's data. Must be present if codable=True,
             must be None if codable=False.
-        unambiguous_code_descriptive (Optional[str]): Descriptive label of the classification category.
-            Must be present if codable=True, must be None if codable=False.
+        unambiguous_code_descriptive (Optional[str]): Descriptive label of the classification
+            category. Must be present if codable=True, must be None if codable=False.
         higher_level_code (Optional[str]): Classification code with X notation to pad to 5 digits.
             Must be present if codable=False, must be None if codable=True.
         reasoning (str): Step by step reasoning behind the classification selected.

--- a/src/industrial_classification_utils/models/response_model.py
+++ b/src/industrial_classification_utils/models/response_model.py
@@ -447,3 +447,42 @@ class RerankingResponse(BaseModel):
                     f"must not exceed n_requested ({self.n_requested})"
                 )
         return self
+
+
+class FinalSICAssignment(BaseModel):
+    """Response model for final assignment of a SIC code.
+
+    Attributes:
+        codable (bool): True if enough information is provided to assign
+            an unambiguous single 5-digit classification code, False otherwise.
+        unambiguous_code (Optional[str]): Full 5-digit classification code
+            assigned based on provided respondent's data. Must be present if codable=True,
+            must be None if codable=False.
+        unambiguous_code_descriptive (Optional[str]): Descriptive label of the classification category.
+            Must be present if codable=True, must be None if codable=False.
+        higher_level_code (Optional[str]): Classification code with X notation to pad to 5 digits.
+            Must be present if codable=False, must be None if codable=True.
+        reasoning (str): Step by step reasoning behind the classification selected.
+    """
+
+    codable: bool = Field(
+        description="True only if enough information is provided to decide an unambiguous "
+        "classification code, False otherwise."
+    )
+    unambiguous_code: Optional[str] = Field(
+        description="Full 5-digit classification code "
+        "assigned based on provided respondent's data. Must be present if codable=True, "
+        "must be None if codable=False."
+    )
+    unambiguous_code_descriptive: Optional[str] = Field(
+        description="Descriptive label of the classification category. "
+        "Must be present if codable=True, must be None if codable=False."
+    )
+    higher_level_code: Optional[str] = Field(
+        description="Classification code with X notation to pad to 5 digits. "
+        "Must be present if codable=False, must be None if codable=True."
+    )
+    reasoning: str = Field(
+        description="Step by step reasoning behind the classification selected.",
+        min_length=50,
+    )


### PR DESCRIPTION
## ✨ Summary

This PR implements SA-247 and creates a new prompt, which is used to make a final SIC assignment. Alongside the prompt, LLM is provided with initial respondent data as well as follow-up questions and corresponding answers to those questions.

Prompt is designed to prioritise assignment of 5-digit SIC code only outputting less granular SIC code (e.g. 4-digit or 2-digit) when multiple candidates have very similar confidence scores and no single code can be identified as the clear best match.

## 📜 Changes Introduced

- [ ] (feat:) added `_sic_template_final_assignment` template in `src/industrial_classification_utils/llm/prompt`
- [ ] (feat:) added `final_sic_code` function in `src/industrial_classification_utils/llm/llm`
- [ ] (feat:) added `FinalSICAssignment` in `src/industrial_classification_utils/models/response_model`
- [ ] (feat:) added script for testing `src/industrial_classification_utils/llm/llm_final_prompt_example`

## TODO
- [ ] test for final_sic_code

## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Run `poetry run python src/industrial_classification_utils/llm/llm_final_prompt_example.py`