### PR TITLE
Script to add followup questions in evaluation pipeline

### DIFF
--- a/scripts/stage_3_add_open_questions.py
+++ b/scripts/stage_3_add_open_questions.py
@@ -44,7 +44,7 @@ import json
 import os
 from argparse import ArgumentParser as AP
 from datetime import UTC, datetime
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -194,7 +194,7 @@ def try_to_restart(
         )
 
 
-def get_open_question(row: pd.Series) -> Any:  # pylint: disable=C0103, W0613
+def get_open_question(row: pd.Series) -> str:  # pylint: disable=C0103, W0613
     """Using the provided row data, call an LLM to generate an open follow-up question.
     Intended for use as a `.apply()` operation to create a new colum in a pd.DataFrame object.
 
@@ -217,7 +217,8 @@ def get_open_question(row: pd.Series) -> Any:  # pylint: disable=C0103, W0613
         job_description=row[JOB_DESCRIPTION_COL],
         llm_output=sa_sic_rag[0].sic_candidates,  # type: ignore
     )
-
+    if sic_followup_object.followup is None:
+        return ""
     return sic_followup_object.followup
 
 


### PR DESCRIPTION
# 📌 Script to add followup questions in evaluation pipeline

## ✨ Summary

This script performs the third stage of processing in the "two-prompt" pipeline, adding a "followup_question" column to the dataset.

The script is adapted from the `stage_k_template.py` template script, so I will only clarify the changes here;
* set up a ClassificationLLM instance
* convert `get_x()` to `get_open_question()`, which queries the ClassificationLLM for a followup question. 

## 📜 Changes Introduced

- [x] feat: script to retrieve followup questions
- [x] feat: updates to the tracked metadata - ClassificationLLM's model and location
- [x] feat: adds one column to the dataset in the evaluation pipeline, described above

## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

1) Retrieve the 20-row `stage_2_unambiguous_codability_added/` output data from the GCP Bucket
2) Temporarily change the LLM model's location in `src/industrial_classification_utils/llm/llm.py` (line 99) to `location="europe-west9"`
3) Run 
`./stage_3_add_open_questions.py -n extended_20rows -b 10 ./extendedKB_2025_08_08_16.gz ./extendedKB_metadata_2025_08_08_16.json TEST`
4) Visually check the CSV and JSON outputs in the new `TEST/` folder
