### PR TITLE
Clean the upper-case input descriptions

### DIFF
--- a/scripts/stage_1_add_semantic_search.py
+++ b/scripts/stage_1_add_semantic_search.py
@@ -61,6 +61,7 @@ import json
 import os
 from argparse import ArgumentParser as AP
 from datetime import UTC, datetime
+from re import sub as regex_sub
 from typing import Optional
 
 import numpy as np
@@ -126,7 +127,8 @@ def parse_args():
 
 
 def clean_text(text: str) -> str:
-    """Cleans a text string by removing newlines and standardizing case.
+    """Cleans a text string by removing newlines, converting arbitrary
+    whitespace to a single space, and standardizing case.
 
     Args:
         text (str): The input string to clean.
@@ -135,6 +137,7 @@ def clean_text(text: str) -> str:
         str: The cleaned string.
     """
     text = text.replace("\n", " ")
+    text = regex_sub(r"\s+", " ", text)
     text = text.lower()
     text = text.capitalize()
     return text

--- a/scripts/stage_1_add_semantic_search.py
+++ b/scripts/stage_1_add_semantic_search.py
@@ -125,6 +125,21 @@ def parse_args():
     return parser.parse_args()
 
 
+def clean_text(text: str) -> str:
+    """Cleans a text string by removing newlines and standardizing case.
+
+    Args:
+        text (str): The input string to clean.
+
+    Returns:
+        str: The cleaned string.
+    """
+    text = text.replace("\n", " ")
+    text = text.lower()
+    text = text.capitalize()
+    return text
+
+
 def try_to_restart(
     output_folder, output_shortname, input_data_file, input_metadata_json, batch_size
 ):
@@ -357,6 +372,10 @@ if __name__ == "__main__":
         METADATA["start_unix_timestamp"] = datetime.now(UTC).timestamp()
         METADATA["batch_size"] = args.batch_size
         df = pd.read_csv(args.input_data_file)
+        # Clean the Survey Response columns:
+        df[INDUSTRY_DESCR_COL] = df[INDUSTRY_DESCR_COL].apply(clean_text)
+        df[JOB_DESCRIPTION_COL] = df[JOB_DESCRIPTION_COL].apply(clean_text)
+        df[JOB_TITLE_COL] = df[JOB_TITLE_COL].apply(clean_text)
         print("Input loaded")
 
     print("running semantic search...")


### PR DESCRIPTION
# 📌 Clean the upper-case input descriptions

## ✨ Summary

Adds a pre-processing step after loading the input CSV, converting the input descriptions from upper-case to sentence-case.

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] feat: Adds a function, `clean_text()`, which converts input text to sentence-case
- [x] feat: adds a pre-processing step, applying `clean_text` to each input description column

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

1) Obtain test dataset - I recommend using the 100 row random sample input file, from the `original_datasets/` folder in the GCP Bucket.

2) Start up the Vector Store locally. 
* If you have it set up, just run the startup bash script I provided previously
* Otherwise, open a second terminal, navigate to the `sic-classification-vector-store` repo, activate the poetry environment, and run `make run-vector-store`

3) Make the initial metadata file / use an existing one (just for test purposes) 
* Copy the template in the script, and tailor the values as required

4) Process the test data with the script;
```python
python stage_1.py -n test_stage1 -b 5 path/to/testdata.csv path/to/initial_metadata.json test_outputdir
```
5) Check the `.csv` output visually - confirm that the values under the "sic2007_employee", "soc2020_job_title", "soc2020_job_description" are in sentence-case rather than all upper-case.
