### PR TITLE
SA270b Chage sic_candidates outputs

### DIFF
--- a/scripts/metadata.json
+++ b/scripts/metadata.json
@@ -1,0 +1,12 @@
+{
+    "original_dataset_name": "DSC_Rep_Sample.csv",
+    "embedding_model_name": "all-MiniLM-L6-v2",
+    "llm_model_name": "gemini-1.0-pro",
+    "llm_location": "eu-west2",
+    "sic_index_file": "uksic2007indexeswithaddendumdecember2022.xlsx",
+    "sic_structure_file": "publisheduksicsummaryofstructureworksheet.xlsx",
+    "sic_condensed_file": "sic_2d_condensed.txt",
+    "matches": 20,
+    "sic_index_size": 34663,
+    "runner_initials": "PS"
+}

--- a/scripts/metadata_stage2.json
+++ b/scripts/metadata_stage2.json
@@ -1,0 +1,12 @@
+{
+    "original_dataset_name": "STGK_2025_08_06_16.csv",
+    "embedding_model_name": "all-MiniLM-L6-v2",
+    "llm_model_name": "gemini-1.0-pro",
+    "llm_location": "eu-west2",
+    "sic_index_file": "uksic2007indexeswithaddendumdecember2022.xlsx",
+    "sic_structure_file": "publisheduksicsummaryofstructureworksheet.xlsx",
+    "sic_condensed_file": "sic_2d_condensed.txt",
+    "matches": 20,
+    "sic_index_size": 34663,
+    "runner_initials": "PS"
+}

--- a/scripts/stage_2_get_rag_sic_code.py
+++ b/scripts/stage_2_get_rag_sic_code.py
@@ -217,9 +217,11 @@ def get_rag_response(row: pd.Series) -> dict[str, Any]:  # pylint: disable=C0103
 
     result = {
         "final_sic_code": sa_rag_response[0].sic_code,
-        "sic_candidates": sa_rag_response[0].sic_candidates,
+        "sic_candidates": [
+            {"sic_code": i.sic_code, "likelihood": i.likelihood}
+            for i in sa_rag_response[0].sic_candidates
+        ],
     }
-
     return result
 
 


### PR DESCRIPTION
## ✨ Summary

Change sic_candidates to include only sic_code and likelihood for potential candidates.

## 📜 Changes Introduced

- Access sic_candidates from sa_rag_sic_code as an object.
- For result, save as a list of dictionaries, instead of a pydantic object.

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

1. Access data produced during stage_1 from the GCP bucket.
2. Run `scripts/stage_2_get_rag_sic_code.py -b 10  TEST/data.gz scripts/metadata.json TEST`,
    Where:
     - `scripts/stage_2_get_rag_sic_code.py` is the path to the `stage_2_get_rag_sic_code.py` file;
     - `TEST/data.gz` is the data from stage_1;
     - `scripts/metadata.json` is the JSON file containing the processing metadata;
     - `TEST` is the output folder, where the data will be saved.
