### PR TITLE
SA-334 update llm methods to use raw semantic search output

### DIFF
--- a/scripts/stage_2_add_unambiguously_codable_status.py
+++ b/scripts/stage_2_add_unambiguously_codable_status.py
@@ -89,17 +89,11 @@ def get_unambiguous_sic(
     Returns:
         result (dict): the codability, assigned code (or None), and the alternatice SIC candidates.
     """
-    short_list = c_llm._prompt_candidate_list(  # pylint: disable=W0212
-        row["semantic_search_results"],
-        code_digits=CODE_DIGITS,
-        candidates_limit=CANDIDATES_LIMIT,
-    )
-
     sa_response = c_llm.unambiguous_sic_code(
         industry_descr=row[MERGED_INDUSTRY_DESC_COL],
+        semantic_search_results=row["semantic_search_results"],
         job_title=row[JOB_TITLE_COL],
         job_description=row[JOB_DESCRIPTION_COL],
-        sic_candidates=short_list,
     )
 
     result = {

--- a/src/industrial_classification_utils/llm/llm.py
+++ b/src/industrial_classification_utils/llm/llm.py
@@ -442,7 +442,7 @@ class ClassificationLLM:
 
         return validated_answer, short_list, call_dict
 
-    def unambiguous_sic_code(
+    def unambiguous_sic_code(  # noqa: PLR0913
         self,
         industry_descr: str,
         semantic_search_results: list[dict],
@@ -473,20 +473,26 @@ class ClassificationLLM:
 
         """
         sic_candidates = self._prompt_candidate_list(
-            short_list=semantic_search_results, 
+            short_list=semantic_search_results,
             code_digits=code_digits,
             candidates_limit=candidates_limit,
         )
 
-        job_title = "Unknown" if (job_title is None or job_title in {"", " "}) else job_title
-        job_description = "Unknown" if (job_description is None or job_description in {"", " "}) else job_description
+        job_title = (
+            "Unknown" if (job_title is None or job_title in {"", " "}) else job_title
+        )
+        job_description = (
+            "Unknown"
+            if (job_description is None or job_description in {"", " "})
+            else job_description
+        )
 
         call_dict = {
-                "industry_descr": industry_descr,
-                "job_title": job_title,
-                "job_description": job_description,
-                "sic_candidates": sic_candidates,
-            }
+            "industry_descr": industry_descr,
+            "job_title": job_title,
+            "job_description": job_description,
+            "sic_candidates": sic_candidates,
+        }
 
         if self.verbose:
             final_prompt = self.sic_prompt_unambiguous.format(**call_dict)

--- a/src/industrial_classification_utils/llm/llm_codability_example.py
+++ b/src/industrial_classification_utils/llm/llm_codability_example.py
@@ -444,8 +444,8 @@ sa_response = uni_chat.unambiguous_sic_code(
     semantic_search_results=EXAMPLE_EMBED_SHORT_LIST,
     job_title=JOB_TITLE,
     job_description=JOB_DESCRIPTION,
-    code_digits=5, 
-    candidates_limit=7
+    code_digits=5,
+    candidates_limit=7,
 )
 
 pprint(sa_response[0].model_dump(), indent=2, width=80)

--- a/src/industrial_classification_utils/llm/llm_codability_example.py
+++ b/src/industrial_classification_utils/llm/llm_codability_example.py
@@ -439,15 +439,13 @@ EXAMPLE_EMBED_SHORT_LIST = [
 
 uni_chat = ClassificationLLM(model_name=LLM_MODEL, verbose=True)
 
-SIC_CANDIDATES = uni_chat._prompt_candidate_list(  # pylint: disable=protected-access
-    EXAMPLE_EMBED_SHORT_LIST, code_digits=5, candidates_limit=7
-)
-
 sa_response = uni_chat.unambiguous_sic_code(
     industry_descr=ORG_DESCRIPTION,
+    semantic_search_results=EXAMPLE_EMBED_SHORT_LIST,
     job_title=JOB_TITLE,
     job_description=JOB_DESCRIPTION,
-    sic_candidates=SIC_CANDIDATES,
+    code_digits=5, 
+    candidates_limit=7
 )
 
 pprint(sa_response[0].model_dump(), indent=2, width=80)

--- a/src/industrial_classification_utils/llm/llm_embedding_example.py
+++ b/src/industrial_classification_utils/llm/llm_embedding_example.py
@@ -73,11 +73,12 @@ response, short_list, prompt = gemini_llm.sa_rag_sic_code(
 )
 # Print the response
 print(response)
-# print(short_list)
-# print(prompt)
 
 query_response, call_dict = gemini_llm.unambiguous_sic_code(
-    ORG_DESCRIPTION, JOB_TITLE, JOB_DESCRIPTION
+    industry_descr=ORG_DESCRIPTION,
+    semantic_search_results=EXAMPLE_EMBED_SHORT_LIST,
+    job_title=JOB_TITLE,
+    job_description=JOB_DESCRIPTION,
 )
 
 # Print the response

--- a/src/industrial_classification_utils/llm/llm_formulate_questions.py
+++ b/src/industrial_classification_utils/llm/llm_formulate_questions.py
@@ -436,13 +436,11 @@ EXAMPLE_EMBED_SHORT_LIST = [
     },
 ]
 
-candidate_list = uni_chat._prompt_candidate_list(EXAMPLE_EMBED_SHORT_LIST)  # type: ignore
-
 sic_response_unambiguous = uni_chat.unambiguous_sic_code(
     industry_descr=ORG_DESCRIPTION,
+    semantic_search_results=EXAMPLE_EMBED_SHORT_LIST,
     job_title=JOB_TITLE,
     job_description=JOB_DESCRIPTION,
-    sic_candidates=candidate_list,
 )
 
 # Formulate Open Question


### PR DESCRIPTION
# 📌 Update `unambiguous_sic_code` to operate directly on semantic search output

## ✨ Summary

Currently, the semantic search output needs to be formatted into a short_list using a private method of the ClassificationLLM object. 
This PR brings that formatting within the `unambiguous_sic_code` method, allowing it to act directly on the semantic search output and avoids the API / evaluation pipeline needing to invoke private class methods.

## 📜 Changes Introduced

- [x] feat: `unambiguous_sic_code` updated to operate on semantic search output
- [x] chore: evaluation pipeline stage 2 script updated to reflect this change
- [x] chore: tests / examples within `src/.../llm/` updated to reflect this change

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

#### Test the changes to `unambiguous_sic_code`:

Run the examples / test cases `llm_codability_example.py`, `llm_embedding_example.py` and `llm_forlmulate_questions.py` in `sic-classification-utils/src/industrial_classification_utils/llm/`

#### Test the changes to the evaluation pipeline:
Use the bash runner script with the 100-row sample output to run the two-prompt pipeline. 
Note, you can comment out STG3-5 in the runner script to save time.
Note: make sure the vector store is running (and ready), and that you have authenticated gcloud before starting.

`bash ./run_full_pipeline.sh  2 SA334_TEST /path/to/random100row.csv /path/to/random100row_metadata.json 20`