### PR TITLE
bump version to 0.1.12 for sic-classification-library v0.1.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sic-classification-utils"
-version = "0.1.11"
+version = "0.1.12"
 description = "Utility functions used for SIC classification"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

<!-- Provide a short, clear summary of what this PR does. Keep it concise but informative. -->

## 📜 Changes Introduced

bumped `pyproject.toml` of repo to `version = "0.1.12"`

Releasing sic-classification-utils v0.1.12 so consumers (e.g. survey-assist-api) can depend on a tagged release that pins sic-classification-library v0.1.4, because v0.1.11 still pins library v0.1.3 and Poetry won’t resolve both

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Check `version = "0.1.12"` is there